### PR TITLE
:bug: Bug | Fix direct links

### DIFF
--- a/packages/ui/src/components/molecules/topbar/networkSelect.tsx
+++ b/packages/ui/src/components/molecules/topbar/networkSelect.tsx
@@ -63,16 +63,16 @@ export const NetworkSelect = ({
   const [selectedValue, setSelectedValue] = useState<string | undefined>(defaultValue);
   const [listboxVisible, setListboxVisible] = useState<boolean>(false);
 
-  const handleSelect = (value: string) => {
+  const handleSelect = (value: string, runOnChange: boolean = true) => {
     setSelectedValue(value);
     setListboxVisible(false);
-    if (onChange) {
+    if (onChange && runOnChange) {
       onChange(value);
     }
   };
 
   useEffect(() => {
-    value && handleSelect(value);
+    value && handleSelect(value, false);
   }, [value]);
 
   const renderSelectedValue = (value: string | undefined, options: Option[]) => {


### PR DESCRIPTION
### 🛠 Changes being made

Possible fix for direct links so they don't send you to the dashboard. Can only be tested on live version. Before, the network would be gotten from the url, then set the networkSelect to the right network visually, but that triggered the onChange which would send you back to the dashboard.

### 🏎 Quality check

- [x] Did you check the responsive design of the changes?
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?
