### PR TITLE
:recycle: Nfts | make nft grid more flexible

### DIFF
--- a/apps/web/src/components/clientPages/nfts.tsx
+++ b/apps/web/src/components/clientPages/nfts.tsx
@@ -98,7 +98,12 @@ export default function NFTS() {
         variant="tertiary"
       />
       {isGridView ? (
-        <div className="flex flex-wrap gap-6 justify-center desktop:justify-start">
+        <div
+          className={'w-full grid relative mb-10 gap-6'}
+          style={{
+            gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+          }}
+        >
           {nfts.map((nft) => (
             <NftCard
               chain={nft.chain}

--- a/packages/ui/src/components/molecules/nft/nftCard.tsx
+++ b/packages/ui/src/components/molecules/nft/nftCard.tsx
@@ -21,11 +21,19 @@ export const NftCard = ({
 }: NftCardGridProps) => {
   return (
     <div className="flex flex-col  overflow-hidden">
-      <div className="max-w-72 hidden desktop:block aspect-square ">
-        <img alt={title} className=" object-cover w-full h-full  rounded-2xl" src={image} />
+      <div className="hidden desktop:block aspect-square ">
+        <img
+          alt={title}
+          className=" object-cover w-full h-full aspect-square rounded-2xl"
+          src={image}
+        />
       </div>
-      <div className="max-w-96 desktop:hidden aspect-video">
-        <img alt={title} className=" object-cover w-full h-full  rounded-2xl" src={image} />
+      <div className="desktop:hidden aspect-video">
+        <img
+          alt={title}
+          className=" object-cover w-full aspect-video h-full rounded-2xl"
+          src={image}
+        />
       </div>
 
       <div className="mt-3">
@@ -43,9 +51,6 @@ export const NftCard = ({
 
       <div className="flex justify-between items-center mt-4">
         <div className="flex items-center gap-1">
-          <Typography color="onBackgroundLow" variant="footer">
-            {'Active on chain'}
-          </Typography>
           <ImageContainer
             alt="Chain logo"
             className="rounded-full"


### PR DESCRIPTION
### 🛠 Changes being made

Changed nft grid view to use grid with autocolumns to make the grid items stretch and shrink so it doesn't leave whitespace on a row

### 🏎 Quality check

- [x] Did you check the responsive design of the changes?
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?
