### PR TITLE
:recycle: Details tabs | remove titles and add count to tabs

### DIFF
--- a/apps/web/src/components/clientPages/accountDetails.tsx
+++ b/apps/web/src/components/clientPages/accountDetails.tsx
@@ -53,6 +53,7 @@ import { useBasePath } from '../../utils/hooks/useBasePath.ts';
 import { useFavouritesStore } from '../../store/favouritesStore.ts';
 import { useChainNetwork } from '../../providers/chainNetworkProvider.tsx';
 import { useInitializeFavourites } from '../../store/favouritesStore.ts';
+import { shortString } from '@repo/ui/utils';
 
 export const AccountDetails = ({ paramAccount }: { paramAccount: string }) => {
   useInitializeFavourites();
@@ -225,17 +226,26 @@ export const AccountDetails = ({ paramAccount }: { paramAccount: string }) => {
     createDetails(
       'Address',
       <div className="flex flex-row gap-1.5 items-baseline ">
-        <Typography variant={'paragraph-sm'}>{account?.address}</Typography>
+        <Typography className={'hidden desktop:inline'} variant={'paragraph-sm'}>
+          {account?.address}
+        </Typography>
+        <Typography className={'desktop:hidden'} variant={'paragraph-sm'}>
+          {shortString(account?.address ?? ' ', 16, 'center')}
+        </Typography>
         <CopyIcon content={account?.address || ''} size={'xxs'} />
       </div>,
     ),
     createDetails(
       'Public Key',
       <div className="flex flex-row gap-1.5 items-baseline ">
-        <Typography variant={'paragraph-sm'}>{account?.publicKey}</Typography>
+        <Typography className={'hidden desktop:inline'} variant={'paragraph-sm'}>
+          {account?.publicKey}
+        </Typography>
+        <Typography className={'desktop:hidden'} variant={'paragraph-sm'}>
+          {shortString(account?.publicKey ?? ' ', 16, 'center')}
+        </Typography>
         <CopyIcon content={account?.publicKey || ''} size={'xxs'} />
       </div>,
-      'half',
     ),
   ];
 
@@ -361,14 +371,12 @@ export const AccountDetails = ({ paramAccount }: { paramAccount: string }) => {
       value: 1,
       label: 'Details',
       icon: 'InfoSquare',
-      content: (
-        <DetailsSection data={details} json={account as unknown as DataType} title={'Details'} />
-      ),
+      content: <DetailsSection data={details} json={account as unknown as DataType} />,
     },
     ...(isValidator
       ? [
           {
-            content: <DetailsSection data={validatorDetails} title={'Validator Details'} />,
+            content: <DetailsSection data={validatorDetails} />,
             icon: 'Flag',
             label: 'Validator',
             value: 2,
@@ -383,11 +391,6 @@ export const AccountDetails = ({ paramAccount }: { paramAccount: string }) => {
             icon: 'Cube',
             content: (
               <FlexGrid className={'w-full'} direction={'col'} gap={'4.5xl'}>
-                <SectionHeader
-                  count={blocksMeta?.total}
-                  title={`${validator?.account.name}'s blocks`}
-                  titleSizeNotLink={'h5'}
-                />
                 <TableContainer
                   currentNumber={blocksPagination.pageNumber}
                   defaultValue={blocksPagination.limit}
@@ -410,13 +413,9 @@ export const AccountDetails = ({ paramAccount }: { paramAccount: string }) => {
       value: isValidator ? 4 : 2,
       label: 'Transactions',
       icon: 'SwitchHorizontal',
+      count: transactionsMeta?.total,
       content: (
         <FlexGrid className={'w-full'} direction={'col'} gap={'4.5xl'}>
-          <SectionHeader
-            count={transactionsMeta?.total}
-            title={`${account?.name} transactions`}
-            titleSizeNotLink={'h5'}
-          />
           <TableContainer
             currentNumber={transactionsPagination.pageNumber}
             defaultValue={transactionsPagination.limit}
@@ -441,13 +440,9 @@ export const AccountDetails = ({ paramAccount }: { paramAccount: string }) => {
       value: isValidator ? 5 : 3,
       label: 'Stakes',
       icon: 'LayersThree',
+      count: outgoingStakes.length,
       content: (
         <FlexGrid className={'w-full'} direction={'col'} gap={'4.5xl'}>
-          <SectionHeader
-            count={outgoingStakes.length}
-            title={`${account?.name}'s stakes`}
-            titleSizeNotLink={'h5'}
-          />
           <TableContainer
             headCols={validatorStakeOutgoingTableHead}
             keyPrefix={'validator-stakes'}
@@ -460,13 +455,9 @@ export const AccountDetails = ({ paramAccount }: { paramAccount: string }) => {
       value: isValidator ? 6 : 4,
       label: 'Tokens',
       icon: 'CryptoCurrency',
+      count: outgoingStakes.length,
       content: (
         <FlexGrid className={'w-full'} direction={'col'} gap={'4.5xl'}>
-          <SectionHeader
-            count={outgoingStakes.length}
-            title={`${account?.name}'s tokens`}
-            titleSizeNotLink={'h5'}
-          />
           <TableContainer
             headCols={userTokensTableHead}
             keyPrefix={'validator-blocks'}
@@ -480,8 +471,7 @@ export const AccountDetails = ({ paramAccount }: { paramAccount: string }) => {
       label: 'NFTs',
       icon: 'Image',
       content: (
-        <FlexGrid className={'w-full relative mb-10'} direction={'col'} gap={'4.5xl'}>
-          <SectionHeader title={`${account?.name}'s NFTs`} titleSizeNotLink={'h5'} />
+        <div className={'w-full relative mb-10 pt-5xl'}>
           <IconButton
             className="absolute top-0 right-0"
             icon={isGridView ? 'Menu' : 'DotsVertical'}
@@ -505,20 +495,16 @@ export const AccountDetails = ({ paramAccount }: { paramAccount: string }) => {
           ) : (
             <TableContainer headCols={nftsTableHead} keyPrefix={'account-nfts'} rows={nftsRows} />
           )}
-        </FlexGrid>
+        </div>
       ),
     },
     {
       value: isValidator ? 8 : 6,
       label: 'Events',
       icon: 'List',
+      count: eventsMeta?.total,
       content: (
         <FlexGrid className={'w-full'} direction={'col'} gap={'4.5xl'}>
-          <SectionHeader
-            count={eventsMeta?.total}
-            title={`${account?.name}'s events`}
-            titleSizeNotLink={'h5'}
-          />
           <TableContainer
             currentNumber={eventsPagination.pageNumber}
             defaultValue={eventsPagination.limit}

--- a/apps/web/src/components/clientPages/blockDetails.tsx
+++ b/apps/web/src/components/clientPages/blockDetails.tsx
@@ -26,7 +26,7 @@ import { usePagination } from '../../utils/hooks/usePagination.ts';
 import { Link } from '@repo/ui/atoms';
 import { useBasePath } from '../../utils/hooks/useBasePath.ts';
 import { Currency } from '../currency.tsx';
-import {useChainNetwork} from "../../providers/chainNetworkProvider.tsx";
+import { useChainNetwork } from '../../providers/chainNetworkProvider.tsx';
 
 export const BlockDetails = ({ params }: { params: { id: string } }) => {
   const { id } = params;
@@ -217,25 +217,15 @@ export const BlockDetails = ({ params }: { params: { id: string } }) => {
       value: 1,
       label: 'Details',
       icon: 'InfoSquare',
-      content: (
-        <DetailsSection
-          data={details}
-          json={block as unknown as DataType}
-          title={'Block Details'}
-        />
-      ),
+      content: <DetailsSection data={details} json={block as unknown as DataType} />,
     },
     {
       value: 2,
       label: 'Transactions',
       icon: 'SwitchHorizontal',
+      count: transactionsMeta?.total || '0',
       content: (
         <FlexGrid className="w-full mx-auto" direction={'col'} gap={'4.5xl'}>
-          <SectionHeader
-            count={transactionsMeta?.total || '0'}
-            title={'Block transactions'}
-            titleSizeNotLink={'h5'}
-          />
           {transactions?.length && transactions.length > 0 ? (
             <TableContainer
               currentNumber={transactionsPagination.pageNumber}
@@ -270,7 +260,6 @@ export const BlockDetails = ({ params }: { params: { id: string } }) => {
       icon: 'List',
       content: (
         <FlexGrid className={'w-full'} direction={'col'} gap={'4.5xl'}>
-          <SectionHeader count={eventsMeta?.total} title={'Block events'} titleSizeNotLink={'h5'} />
           <TableContainer
             currentNumber={eventsPagination.pageNumber}
             defaultValue={eventsPagination.limit}

--- a/apps/web/src/components/clientPages/transactionDetails.tsx
+++ b/apps/web/src/components/clientPages/transactionDetails.tsx
@@ -18,8 +18,8 @@ import { EventsType, TransactionType } from '../../utils/types.ts';
 import { callGetEvents, callGetTransactions } from '../../utils/api/apiCalls.tsx';
 import { Link } from '@repo/ui/atoms';
 import { useBasePath } from '../../utils/hooks/useBasePath.ts';
-import {Currency} from "../currency.tsx";
-import {useChainNetwork} from "../../providers/chainNetworkProvider.tsx";
+import { Currency } from '../currency.tsx';
+import { useChainNetwork } from '../../providers/chainNetworkProvider.tsx';
 
 export const TransactionDetails = ({ params }: { params: { id: string } }) => {
   const { id } = params;
@@ -254,25 +254,15 @@ export const TransactionDetails = ({ params }: { params: { id: string } }) => {
       value: 1,
       label: 'Details',
       icon: 'InfoSquare',
-      content: (
-        <DetailsSection
-          data={details}
-          json={transaction as unknown as DataType}
-          title={'Transaction Details'}
-        />
-      ),
+      content: <DetailsSection data={details} json={transaction as unknown as DataType} />,
     },
     {
       value: 2,
       label: 'Events',
       icon: 'List',
+      count: events?.length,
       content: (
         <FlexGrid className={'w-full'} direction={'col'} gap={'4.5xl'}>
-          <SectionHeader
-            count={events?.length}
-            title={'Transaction events'}
-            titleSizeNotLink={'h5'}
-          />
           <TableContainer headCols={eventsTableHead} keyPrefix={'tx-events'} rows={eventsRows} />
         </FlexGrid>
       ),

--- a/packages/ui/src/components/atoms/input/tabButtons.tsx
+++ b/packages/ui/src/components/atoms/input/tabButtons.tsx
@@ -13,6 +13,7 @@ interface TabData {
   label: string;
   icon?: IconComponent;
   content: ReactNode;
+  count?: number | string;
 }
 
 interface TabButtonsProps {
@@ -55,6 +56,18 @@ export const TabButtons = ({
                 <Typography color="" fontWeight="semibold" variant="paragraph-lg">
                   {tab.label}
                 </Typography>
+              )}
+
+              {tab.count !== undefined && tab.count !== null && (
+                <div
+                  className={
+                    'bg-secondary rounded-sm p-1 h-6 min-w-6 items-center justify-center hidden desktop:flex'
+                  }
+                >
+                  <Typography color="onSecondary" variant="paragraph-sm">
+                    {tab.count}
+                  </Typography>
+                </div>
               )}
             </div>
           </Tab>

--- a/packages/ui/src/components/organisms/sections/detailsSection.tsx
+++ b/packages/ui/src/components/organisms/sections/detailsSection.tsx
@@ -17,7 +17,7 @@ import { DataType } from '../../../types/types.ts';
 
 interface DetailsSectionsProps {
   headerWidth?: string;
-  title: string;
+  title?: string;
   data: {
     label: {
       label: string;
@@ -48,15 +48,57 @@ export const DetailsSection = ({
   };
 
   return (
-    <FlexGrid className={'w-full'} component={'section'} direction={'col'} gap={'4.5xl'}>
-      <FlexGrid
-        alignItems="center"
-        className={'w-full'}
-        justify={'between'}
-        mobileDirection={'row'}
-      >
-        <SectionHeader title={title} titleSize={'sm'} titleSizeNotLink={'h5'} />
-        {json && (
+    <FlexGrid className={'w-full relative'} component={'section'} direction={'col'} gap={'4.5xl'}>
+      {title ? (
+        <FlexGrid
+          alignItems="center"
+          className={'w-full'}
+          justify={'between'}
+          mobileDirection={'row'}
+        >
+          <SectionHeader title={title} titleSize={'sm'} titleSizeNotLink={'h5'} />
+          {json && (
+            <Popover
+              button={
+                <IconButton
+                  active={menuOpen}
+                  align={'none'}
+                  icon={'DotsVertical'}
+                  variant={'semiTransparent'}
+                />
+              }
+              isOpen={menuOpen}
+              placement={'bottom-end'}
+              setIsOpen={setMenuOpen}
+            >
+              <Button
+                label={
+                  <Typography
+                    className={'inline-flex items-center gap-sm'}
+                    color={'onBackgroundMedium'}
+                  >
+                    <Icon color={'onBackgroundLow'} icon={'CodeSquare'} size={'xs'} />
+                    {'View as .json'}
+                  </Typography>
+                }
+                onClick={() => setJsonOpen(true)}
+                variant={'transparent'}
+              />
+              <SlideInModal
+                onClose={() => setJsonOpen(false)}
+                open={jsonOpen}
+                title={'View as .json'}
+              >
+                <FlexGrid direction={'col'} gap={'3xl'}>
+                  <JsonViewer copy data={json} startOpen />
+                  <Button align={'right'} label={buttonText} onClick={handleCopyClick} />
+                </FlexGrid>
+              </SlideInModal>
+            </Popover>
+          )}
+        </FlexGrid>
+      ) : (
+        json && (
           <Popover
             button={
               <IconButton
@@ -66,6 +108,7 @@ export const DetailsSection = ({
                 variant={'semiTransparent'}
               />
             }
+            containerClassName={'absolute right-0 top-0'}
             isOpen={menuOpen}
             placement={'bottom-end'}
             setIsOpen={setMenuOpen}
@@ -94,8 +137,8 @@ export const DetailsSection = ({
               </FlexGrid>
             </SlideInModal>
           </Popover>
-        )}
-      </FlexGrid>
+        )
+      )}
       <FlexGrid
         className={'w-full grid grid-cols-2 desktop:flex'}
         direction={'col'}


### PR DESCRIPTION
### 🛠 Changes being made

Removed titles from the tab sections on the details pages and added the count to the tabs instead. Also fixed the positioning for the view as json button now that the title is gone

### 🏎 Quality check

- [x] Did you check the responsive design of the changes?
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?
