### PR TITLE
:recycle: Routes | change chainNetworkStore to use new searchparams

### DIFF
--- a/apps/web/src/app/(user)/layout.tsx
+++ b/apps/web/src/app/(user)/layout.tsx
@@ -1,7 +1,7 @@
 import './globals.css';
 import '@repo/ui/styles.css';
 import type { Metadata } from 'next';
-import { ReactNode } from 'react';
+import {ReactNode, Suspense} from 'react';
 import { Layout } from '../../components/layout/layoutClient.tsx';
 import Favicon from '../../public/images/favicon.ico';
 
@@ -20,7 +20,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body className={'overflow-hidden'}>
-        <Layout>{children}</Layout>
+        <Suspense>
+          <Layout>{children}</Layout>
+        </Suspense>
       </body>
     </html>
   );

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -26,14 +26,14 @@ export function middleware(req: NextRequest) {
 
   if (subdomain !== 'explorer' && subdomain !== 'testnet-explorer') {
     url.searchParams.set('network', 'mainnet');
-    url.searchParams.set('app', 'klayr');
-    url.pathname = '/klayr';
+    url.searchParams.set('app', 'klayr_mainchain');
+    url.pathname = '/klayr_mainchain';
     return NextResponse.redirect(url);
   }
 
   if (pathname === '/') {
-    url.searchParams.set('app', 'klayr');
-    url.pathname = '/klayr';
+    url.searchParams.set('app', 'klayr_mainchain');
+    url.pathname = '/klayr_mainchain';
     return NextResponse.redirect(url);
   }
 

--- a/apps/web/src/store/chainNetworkStore.ts
+++ b/apps/web/src/store/chainNetworkStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { defaultChain } from '../utils/constants.tsx';
 import { useGatewayClientStore } from './clientStore.ts';
-import { usePathname } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
 import { ChainType, ChainTokenType } from '../utils/types.ts';
 import { callGetChains, callGetChainTokens } from '../utils/api/apiCalls.tsx';
@@ -31,28 +31,19 @@ export const useChainNetworkStore = create<ChainNetworkStoreProps>((set) => {
 });
 
 export const useInitializeCurrentChain = () => {
-  const pathname = usePathname();
-  const chains = useChainNetworkStore((state) => state.chains);
   const setChains = useChainNetworkStore((state) => state.setChains);
   const setCurrentChain = useChainNetworkStore((state) => state.setCurrentChain);
   const currentNetwork = useChainNetworkStore((state) => state.currentNetwork);
   const setCurrentNetwork = useChainNetworkStore((state) => state.setCurrentNetwork);
   const networks = useChainNetworkStore((state) => state.networks);
-  const currentChain = useChainNetworkStore((state) => state.currentChain);
   const setBaseUrl = useGatewayClientStore((state) => state.setBaseURL);
 
+  const searchParams = useSearchParams();
+
   useEffect(() => {
-    const networkSubdomain = window.location.hostname.split('.')[0].split('-')[0];
-    const network =
-      networkSubdomain === 'explorer'
-        ? networks[0]
-        : networks.find((network) => network === networkSubdomain);
-    if (window.location.hostname !== 'localhost') {
-      setCurrentNetwork(network ?? 'mainnet');
-    } else {
-      setCurrentNetwork(currentChain.networkType);
-    }
-  }, [pathname]);
+    const networkParam = searchParams.get('network');
+    networkParam && networks.includes(networkParam) ? setCurrentNetwork(networkParam) : setCurrentNetwork(networks[0]);
+  }, [searchParams]);
 
   useEffect(() => {
     const fetchChains = async () => {
@@ -78,11 +69,15 @@ export const useInitializeCurrentChain = () => {
         });
         setChains(chainsWithTokens);
 
-        const firstSubDir = pathname.split('/')[1];
-        const matchingChains = chainsWithTokens?.filter((chain) => chain.chainName === firstSubDir);
+        const chainParam = searchParams.get('app')
+        const matchingChains = chainsWithTokens?.filter((chain) => chain.chainName === chainParam);
         const chainMatch = matchingChains?.find((chain) => chain.networkType === currentNetwork);
-        //console.log('matchingChains', matchingChains, '\nfirstSubDir', firstSubDir, '\nchains', chainsWithTokens, '\nchainMatch', chainMatch);
-        setCurrentChain(chainMatch ?? chains[0] ?? defaultChain);
+        //console.log('matchingChains', matchingChains, '\nfirstSubDir', chainParam, '\nchains', chainsWithTokens, '\nchainMatch', chainMatch);
+        if (chainMatch) {
+          //console.log('baseUrl', chainMatch.serviceURLs[0]);
+          setBaseUrl(chainMatch.serviceURLs[0].http);
+          setCurrentChain(chainMatch);
+        }
       } catch (error) {
         console.error('Error fetching chains', error);
       }
@@ -90,8 +85,4 @@ export const useInitializeCurrentChain = () => {
 
     fetchChains();
   }, [currentNetwork]);
-
-  useEffect(() => {
-    setBaseUrl(currentChain?.serviceURLs[0].http ?? defaultChain?.serviceURLs[0].http);
-  }, [currentChain]);
 };


### PR DESCRIPTION
### 🛠 Changes being made

Made it so that the chainNetworkStore gets the network and chain from searchparams set by the middleware file instead of getting it from the url

### 🏎 Quality check

- [x] Did you check the responsive design of the changes?
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?
