### PR TITLE
:recycle: Routing | update useBasePath.ts to use the new searchParams

### DIFF
--- a/apps/web/src/utils/hooks/useBasePath.ts
+++ b/apps/web/src/utils/hooks/useBasePath.ts
@@ -1,10 +1,6 @@
-import { usePathname } from 'next/navigation';
-import {useChainNetworkStore} from "../../store/chainNetworkStore.ts";
+import { useSearchParams } from 'next/navigation';
 
 export const useBasePath = () => {
-  const chains = useChainNetworkStore((state) => state.chains);
-  const pathName = usePathname();
-  const firstSubDir = pathName.split('/')[1];
-  const chainMatch = chains?.find((chain) => chain.chainName === firstSubDir);
-  return !chainMatch || firstSubDir === 'klayr_mainchain' ? '' : `/${firstSubDir}`;
+  const searchParams = useSearchParams();
+  return `/${searchParams.get('app')}` ?? '/klayr_mainchain';
 };

--- a/packages/ui/src/components/atoms/navigation/link.tsx
+++ b/packages/ui/src/components/atoms/navigation/link.tsx
@@ -18,6 +18,7 @@ export const Link = ({
   basePath,
   ...props
 }: CustomLinkProps) => {
+
   return !outgoing ? (
     <NextLink className={className} href={`${basePath ? basePath : ''}${href}`} {...props}>
       {children}


### PR DESCRIPTION
### 🛠 Changes being made

Changed useBasePath to use the new searchParams and fixed it so it now always uses the current chainname as the basepath

### 🏎 Quality check

- [x] Did you check the responsive design of the changes?
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?
