### PR TITLE
:bug: News | Fix broken layout

### DIFF
--- a/packages/ui/src/components/organisms/newsCard/newsCard.tsx
+++ b/packages/ui/src/components/organisms/newsCard/newsCard.tsx
@@ -14,7 +14,7 @@ export const NewsCard = ({
   link,
 }: NewsCardProps) => {
   return (
-    <Link href={link} outgoing>
+    <Link className={'contents'} href={link} outgoing>
       <div className="flex flex-col w-full min-h-newsCardContainerMobileHeight desktop:min-h-newsCardContainerHeight group hover:cursor-pointer">
         <NewsCardImage alt={alt} src={src} />
         <NewsTextContent author={author} date={date} description={description} title={title} />


### PR DESCRIPTION
### 🛠 Changes being made

News layout was broken, added `display: contents;` to the link surrounding the news card to fix it.

### 🏎 Quality check

- [ ] Did you check the responsive design of the changes?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
