### PR TITLE
♻️ Stakes | rename stakes id to transaction id

### DIFF
--- a/apps/web/src/utils/helpers/tableHeaders.tsx
+++ b/apps/web/src/utils/helpers/tableHeaders.tsx
@@ -248,7 +248,7 @@ export const validatorEventsTableHead: TableCellType[] = [
 //STAKES
 export const stakesOverviewTableHead: TableCellType[] = [
   {
-    children: 'Stake ID',
+    children: 'Transaction ID',
   },
   {
     children: 'Date',


### PR DESCRIPTION
### 🛠 Changes being made

The change updates the `stakesOverviewTableHead` array to rename the 'Stake ID' column to 'Transaction ID'.

### 🏎 Quality check

- [x] Did you check the responsive design of the changes?
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?
