### PR TITLE
:recycle: 404 | Redirect to 404 when chain does not exist

### DIFF
--- a/apps/web/src/store/chainNetworkStore.ts
+++ b/apps/web/src/store/chainNetworkStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { defaultChain } from '../utils/constants.tsx';
 import { useGatewayClientStore } from './clientStore.ts';
-import { usePathname, useSearchParams } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 import { ChainType, ChainTokenType } from '../utils/types.ts';
 import { callGetChains, callGetChainTokens } from '../utils/api/apiCalls.tsx';
@@ -33,7 +33,6 @@ export const useChainNetworkStore = create<ChainNetworkStoreProps>((set) => {
 export const useInitializeCurrentChain = () => {
   const setChains = useChainNetworkStore((state) => state.setChains);
   const setCurrentChain = useChainNetworkStore((state) => state.setCurrentChain);
-  const currentNetwork = useChainNetworkStore((state) => state.currentNetwork);
   const setCurrentNetwork = useChainNetworkStore((state) => state.setCurrentNetwork);
   const networks = useChainNetworkStore((state) => state.networks);
   const setBaseUrl = useGatewayClientStore((state) => state.setBaseURL);
@@ -45,6 +44,7 @@ export const useInitializeCurrentChain = () => {
 
   const searchParams = useSearchParams();
   const hasMounted = useRef(false);
+  const router = useRouter();
 
   useEffect(() => {
     const networkParam = searchParams.get('network');
@@ -57,11 +57,8 @@ export const useInitializeCurrentChain = () => {
         setBaseUrl(gateways.testnet);
       }
     }
-    //console.log('running network effect')
     networkParam && networks.includes(networkParam) && setCurrentNetwork(networkParam);
-  }, [searchParams, pathName]);
 
-  useEffect(() => {
     const fetchChains = async () => {
       try {
         // Fetch chains
@@ -87,15 +84,12 @@ export const useInitializeCurrentChain = () => {
 
         const chainParam = searchParams.get('app');
         const matchingChains = chainsWithTokens?.filter((chain) => chain.chainName === chainParam);
-        const chainMatch = matchingChains?.find((chain) => chain.networkType === currentNetwork);
-        //console.log('matchingChains', matchingChains, '\napp', chainParam, '\nchains', chainsWithTokens, '\nchainMatch', chainMatch);
+        const chainMatch = matchingChains?.find((chain) => chain.networkType === networkParam);
         if (chainMatch) {
-          //console.log('baseUrl', chainMatch.serviceURLs[0]);
           chainParam !== 'klayr_mainchain' && setBaseUrl(chainMatch.serviceURLs[0].http);
           setCurrentChain(chainMatch);
         } else if (pathName.split('/')[2] !== '404') {
-          console.error('404 no matching chain');
-          //router.push('/klayr_mainchain/404');
+          router.push('/klayr_mainchain/404');
         }
       } catch (error) {
         console.error('Error fetching chains', error);
@@ -107,5 +101,5 @@ export const useInitializeCurrentChain = () => {
     } else {
       hasMounted.current = true;
     }
-  }, [currentNetwork, pathName]);
+  }, [searchParams, pathName]);
 };

--- a/apps/web/src/utils/hooks/useBasePath.ts
+++ b/apps/web/src/utils/hooks/useBasePath.ts
@@ -2,5 +2,5 @@ import { useSearchParams } from 'next/navigation';
 
 export const useBasePath = () => {
   const searchParams = useSearchParams();
-  return `/${searchParams.get('app')}` ?? '/klayr_mainchain';
+  return searchParams.get('app') ? `/${searchParams.get('app')}` : '/klayr_mainchain';
 };


### PR DESCRIPTION
### 🛠 Changes being made

- Moved the function that sets the current chain to the useEffect that sets the network so it only runs once. 
- Added a redirect to the 404 page when the queried chain does not exist on the current network.
- Also added a safeguard that sets the basepath to klayr_mainchain when there are no searchparams (which happens on the 404 page) so you can use the menu when you are on the 404 page.

### 🏎 Quality check

- [x] Did you check the responsive design of the changes?
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?
