### PR TITLE
:bug: Topbar | Fix height not updating when switching network

### DIFF
--- a/apps/web/src/components/layout/topbarClient.tsx
+++ b/apps/web/src/components/layout/topbarClient.tsx
@@ -1,12 +1,12 @@
 'use client';
 import { Topbar } from '@repo/ui/organisms';
-import { Icon, MenuItemProps, Typography } from '@repo/ui/atoms';
+import {Icon, MenuItemProps, SkeletonComponent, Typography} from '@repo/ui/atoms';
 import { useSearchStore } from '../../store/searchStore.ts';
 import React from 'react';
 import { useBasePath } from '../../utils/hooks/useBasePath.ts';
 import { useFavouritesStore } from '../../store/favouritesStore.ts';
 import { useChainNetworkStore, useInitializeCurrentChain } from '../../store/chainNetworkStore.ts';
-import { useNodeStore } from '../../store/nodeStore.ts';
+import {useNodeStore, useUpdateNodeInfo} from '../../store/nodeStore.ts';
 import useMarketcap from '../../utils/hooks/useMarketcap.ts';
 import {FormattedValue} from "../formattedValue.tsx";
 
@@ -21,6 +21,7 @@ interface TopbarClientProps {
 
 export const TopbarClient = ({ logo, mobileMenuItems }: TopbarClientProps) => {
   useInitializeCurrentChain();
+  useUpdateNodeInfo();
   const {
     // marketcap,
     trend,
@@ -44,8 +45,14 @@ export const TopbarClient = ({ logo, mobileMenuItems }: TopbarClientProps) => {
   const kpisObject = [
     {
       keyValue: 'Height: ',
-      contentValue: (
-        <FormattedValue value={nodeInfo?.height} format={'number'} typographyProps={{fontWeight: 'medium'}} />
+      contentValue: nodeInfo?.height ? (
+        <FormattedValue
+          value={nodeInfo?.height}
+          format={'number'}
+          typographyProps={{ fontWeight: 'medium' }}
+        />
+      ) : (
+        <SkeletonComponent width={'16'} height={'4'} />
       ),
       className: 'hidden desktop:flex',
     },

--- a/apps/web/src/store/nodeStore.ts
+++ b/apps/web/src/store/nodeStore.ts
@@ -1,20 +1,31 @@
 import { create } from 'zustand';
 import { NodeInfoType } from '../utils/types.ts';
 import { callGetNodeInfo } from '../utils/api/apiCalls.tsx';
+import {useEffect} from "react";
+import {usePathname} from "next/navigation";
 
 interface NodeStoreProps {
   nodeInfo?: NodeInfoType;
+  setNodeInfo: (nodeInfo: NodeInfoType) => void;
 }
 
 export const useNodeStore = create<NodeStoreProps>((set) => {
-  const fetchNodeInfo = async () => {
-    const data = await callGetNodeInfo();
-    set({ nodeInfo: data as unknown as NodeInfoType });
-  }
-
-  fetchNodeInfo();
-
   return {
     nodeInfo: {} as NodeInfoType,
+    setNodeInfo: (nodeInfo: NodeInfoType) => set({ nodeInfo }),
   }
 });
+
+export const useUpdateNodeInfo = () => {
+  const setNodeInfo = useNodeStore((state) => state.setNodeInfo);
+  const pathName = usePathname();
+
+  useEffect(() => {
+    const fetchNodeInfo = async () => {
+      const data = await callGetNodeInfo();
+      setNodeInfo(data as unknown as NodeInfoType);
+    }
+
+    fetchNodeInfo();
+  }, [pathName]);
+}


### PR DESCRIPTION
### 🛠 Changes being made

Moved the node info call to a hook that get's called in the topbar so it updates the node info store correctly.

### 🏎 Quality check

- [x] Did you check the responsive design of the changes?
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?
