### PR TITLE
:bug: Fix vercel preview 404

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -18,12 +18,10 @@ export function middleware(req: NextRequest) {
     return NextResponse.next();
   }
 
-  // Redirect for Vercel previews: mainchain and mainnet by default, rest has to be done manually
+  // Redirect for Vercel previews: mainchain and testnet by default, rest has to be done manually
   if (hostname.split('.')[1] === 'vercel') {
-    if (url.searchParams.has('network') && url.searchParams.has('app')) {
-      return NextResponse.next(); // Skip the redirect and continue normally
-    }
-    url.searchParams.set('network', 'mainnet');
+    if (url.searchParams.entries.length > 0) return NextResponse.next();
+    url.searchParams.set('network', 'testnet');
     url.searchParams.set('app', 'klayr_mainchain');
 
     return NextResponse.redirect(url);

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -22,7 +22,6 @@ export function middleware(req: NextRequest) {
   if (hostname.split('.')[1] === 'vercel') {
     url.searchParams.set('network', 'mainnet');
     url.searchParams.set('app', 'klayr_mainchain');
-    url.pathname = '/klayr_mainchain';
 
     return NextResponse.redirect(url);
   }

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -18,10 +18,13 @@ export function middleware(req: NextRequest) {
     return NextResponse.next();
   }
 
-  // todo add permanent fix for vercel previews
-  // Temporarily skip the redirect for Vercel previews
+  // Redirect for Vercel previews: mainchain and mainnet by default, rest has to be done manually
   if (hostname.split('.')[1] === 'vercel') {
-    return NextResponse.next();
+    url.searchParams.set('network', 'mainnet');
+    url.searchParams.set('app', 'klayr_mainchain');
+    url.pathname = '/klayr_mainchain';
+
+    return NextResponse.redirect(url);
   }
 
   // Set the default searchParams if the subdomain is not explorer or testnet-explorer (mainly for localhost)

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -20,6 +20,9 @@ export function middleware(req: NextRequest) {
 
   // Redirect for Vercel previews: mainchain and mainnet by default, rest has to be done manually
   if (hostname.split('.')[1] === 'vercel') {
+    if (url.searchParams.has('network') && url.searchParams.has('app')) {
+      return NextResponse.next(); // Skip the redirect and continue normally
+    }
     url.searchParams.set('network', 'mainnet');
     url.searchParams.set('app', 'klayr_mainchain');
 

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -18,13 +18,10 @@ export function middleware(req: NextRequest) {
     return NextResponse.next();
   }
 
-  // Redirect for Vercel previews: mainchain and testnet by default, rest has to be done manually
+  // todo add permanent fix for vercel previews
+  // Temporarily skip the redirect for Vercel previews
   if (hostname.split('.')[1] === 'vercel') {
-    if (url.searchParams.entries.length > 0) return NextResponse.next();
-    url.searchParams.set('network', 'testnet');
-    url.searchParams.set('app', 'klayr_mainchain');
-
-    return NextResponse.redirect(url);
+    return NextResponse.next();
   }
 
   // Set the default searchParams if the subdomain is not explorer or testnet-explorer (mainly for localhost)

--- a/apps/web/src/store/chainNetworkStore.ts
+++ b/apps/web/src/store/chainNetworkStore.ts
@@ -89,7 +89,8 @@ export const useInitializeCurrentChain = () => {
           chainParam !== 'klayr_mainchain' && setBaseUrl(chainMatch.serviceURLs[0].http);
           setCurrentChain(chainMatch);
         } else if (pathName.split('/')[2] !== '404') {
-          router.push('/klayr_mainchain/404');
+          if (window?.location.hostname.includes('vercel')) console.error('404 triggered') // skip 404 page if on vercel preview because middleware doesn't work there
+          else router.push('/klayr_mainchain/404');
         }
       } catch (error) {
         console.error('Error fetching chains', error);


### PR DESCRIPTION
### 🛠 Changes being made

Tried some tests with middleware, didn't work out, resorted to completely disabling the 404 redirect in the `chainNetworkStore` when on a vercel preview

### 🏎 Quality check

- [x] Did you check the responsive design of the changes?
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?
