### PR TITLE
:recycle: Nodes | make flags just slightly rounded instead of pill shaped

### DIFF
--- a/apps/web/src/utils/helpers/TableHelpers/nodeTableHelper.tsx
+++ b/apps/web/src/utils/helpers/TableHelpers/nodeTableHelper.tsx
@@ -19,7 +19,7 @@ export const createNodesRows = (nodes: NodeType[], loading: boolean) => {
               children: (
                 <div className="flex gap-2 items-center">
                   <div
-                    className="w-8 h-6 rounded-full bg-cover bg-center bg-no-repeat"
+                    className="w-8 h-6 rounded-xs bg-cover bg-center bg-no-repeat"
                     style={{
                       backgroundImage: `url(http://purecatamphetamine.github.io/country-flag-icons/3x2/${node.location.countryCode}.svg)`,
                     }}


### PR DESCRIPTION
### 🛠 Changes being made

Made the flags `rounded-xs` (`border-radius: 4px;`)

### 🏎 Quality check

- [x] Did you check the responsive design of the changes?
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?
