### PR TITLE
:recycle: Dashboard | Remove link on performance title

### DIFF
--- a/apps/web/src/components/clientPages/home.tsx
+++ b/apps/web/src/components/clientPages/home.tsx
@@ -1,12 +1,8 @@
 'use client';
 import { NewsCardGrid, PerformanceSection } from '@repo/ui/organisms';
-import {
-  performanceStatsSelectOptions,
-  newsTagColors,
-  currencies,
-} from '../../utils/constants.tsx';
+import { performanceStatsSelectOptions, newsTagColors } from '../../utils/constants.tsx';
 import { FlexGrid, SkeletonComponent } from '@repo/ui/atoms';
-import { use, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { formatDate, cleanText } from '../../utils/helpers/dataHelpers.tsx';
 import { NewsCardPropsArray, NewsCardProps } from '@repo/ui/types';
 import { Currency } from '../currency.tsx';
@@ -145,7 +141,6 @@ export const Home = () => {
   return (
     <FlexGrid className="w-full mx-auto" direction={'col'} gap={'4xl'}>
       <PerformanceSection
-        href={'#'}
         options={performanceStatsSelectOptions}
         setStatsVS={setStatsVS}
         stats={performanceStatsArray}

--- a/packages/ui/src/components/organisms/layout/sectionHeader.tsx
+++ b/packages/ui/src/components/organisms/layout/sectionHeader.tsx
@@ -1,7 +1,7 @@
 import { Typography } from '../../atoms';
 import { Icon } from '../../atoms';
 import { FlexGrid } from '../../atoms';
-import { LinkComponent } from '../../../types/types.ts';
+import { TypographyComponent, TypographyVariant } from '../../../types/types.ts';
 import { Link } from '../../atoms';
 import { cls } from '../../../utils/functions.ts';
 
@@ -13,7 +13,6 @@ interface SectionHeaderProps {
   className?: string;
   href?: string;
   fullWidth?: boolean;
-  titleSizeNotLink?: 'h3' | 'h4' | 'h5' | 'h6';
   basePath?: string;
   linkOutgoing?: boolean;
 }
@@ -21,7 +20,6 @@ interface SectionHeaderProps {
 export const SectionHeader = ({
   title,
   titleSize = 'lg',
-  titleSizeNotLink = 'h3',
   subTitle,
   count,
   className,
@@ -30,6 +28,20 @@ export const SectionHeader = ({
   basePath,
   linkOutgoing,
 }: SectionHeaderProps) => {
+  let titleVariant: TypographyVariant = 'h4';
+  let titleComponent: TypographyComponent = 'h1';
+
+  switch (titleSize) {
+    case 'lg':
+      titleVariant = 'h4';
+      titleComponent = 'h1';
+      break;
+    case 'sm':
+      titleVariant = 'h6';
+      titleComponent = 'h2';
+      break;
+  }
+
   return (
     <FlexGrid
       className={cls([className, 'gap-5 desktop:gap-6 ', fullWidth && 'w-full'])}
@@ -41,9 +53,9 @@ export const SectionHeader = ({
             <Typography
               className=""
               color="gray-1"
-              component={titleSize === 'lg' ? 'h1' : 'h2'}
+              component={titleComponent}
               fontWeight="bold"
-              variant={titleSize === 'lg' ? 'h4' : 'h6'}
+              variant={titleVariant}
             >
               {title}
             </Typography>
@@ -61,9 +73,9 @@ export const SectionHeader = ({
         <FlexGrid alignItems="center" gap="3" justify="center" mobileDirection="row">
           <Typography
             color="gray-1"
-            component={titleSizeNotLink}
+            component={titleComponent}
             fontWeight="bold"
-            variant={titleSizeNotLink}
+            variant={titleVariant}
           >
             {title}
           </Typography>

--- a/packages/ui/src/components/organisms/sections/detailsSection.tsx
+++ b/packages/ui/src/components/organisms/sections/detailsSection.tsx
@@ -57,7 +57,7 @@ export const DetailsSection = ({
           justify={'between'}
           mobileDirection={'row'}
         >
-          <SectionHeader title={title} titleSize={'sm'} titleSizeNotLink={'h5'} />
+          <SectionHeader title={title} titleSize={'sm'} />
           {json && (
             <Popover
               button={


### PR DESCRIPTION
### 🛠 Changes being made

Removed the link from the performance title and moved some things around in the sectionHeader component to fix the size

### 🏎 Quality check

- [x] Did you check the responsive design of the changes?
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?
