### PR TITLE
:bug: Blocks | Fix block id copy triggering the link

### DIFF
--- a/packages/ui/src/components/atoms/input/copyIcon.tsx
+++ b/packages/ui/src/components/atoms/input/copyIcon.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 // components/CopyToClipboardButton.js
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Icon } from '../images/icon';
 import { Tooltip } from '../utilities/tooltip.tsx';
 import { cls } from '../../../utils/functions.ts';
@@ -93,6 +93,11 @@ export const CopyIcon = ({ content, size, hover }: CopyIconProps) => {
     setCopyTooltipText(isCopied ? 'Copied!' : 'Copy');
   }, [isCopied]);
 
+  const onCopy = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    copyToClipboard(content);
+  }
+
   return (
     <Tooltip placement={'bottom'} text={copyTooltipText}>
       <div
@@ -101,7 +106,7 @@ export const CopyIcon = ({ content, size, hover }: CopyIconProps) => {
           hover,
           className: cls(['cursor-pointer']),
         })}
-        onClick={() => copyToClipboard(content)}
+        onClick={(e) => onCopy(e)}
       >
         <Icon
           className={cls([hover ? 'desktop:group-hover/child:inline desktop:hidden' : ''])}


### PR DESCRIPTION
### 🛠 Changes being made

Added preventDefault to the copy button to ensure that it only triggers the copy function and not any onclick on a parent element

### 🏎 Quality check

- [x] Did you check the responsive design of the changes?
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?
