### PR TITLE
♻️ Block Details | Events tab not displaying any events

### DIFF
--- a/apps/web/src/components/clientPages/blockDetails.tsx
+++ b/apps/web/src/components/clientPages/blockDetails.tsx
@@ -284,6 +284,7 @@ export const BlockDetails = ({ params }: { params: { id: string } }) => {
       value: 3,
       label: 'Events',
       icon: 'List',
+      count: eventsMeta?.count || '0',
       content: (
         <FlexGrid className={'w-full'} direction={'col'} gap={'4.5xl'}>
           {events?.length && events.length > 0 ? (

--- a/apps/web/src/components/clientPages/blockDetails.tsx
+++ b/apps/web/src/components/clientPages/blockDetails.tsx
@@ -304,8 +304,8 @@ export const BlockDetails = ({ params }: { params: { id: string } }) => {
           ) : (
             <NotFound
               className="mt-16"
-              headerText={'No transactions found'}
-              subheaderText={'We cannot find any transactions in this block'}
+              headerText={'No events found'}
+              subheaderText={'We cannot find any events in this block'}
             />
           )}
         </FlexGrid>


### PR DESCRIPTION
### 🛠 Changes being made

The change adds a `count` property to the `Events` object, defaulting to '0' if `eventsMeta?.count` is not available.


### 🏎 Quality check

- [x] Did you check the responsive design of the changes?
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?
