### PR TITLE
♻️ Nodes | Flags get pushed to a smaller size by larger country names

### DIFF
--- a/apps/web/src/utils/helpers/TableHelpers/nodeTableHelper.tsx
+++ b/apps/web/src/utils/helpers/TableHelpers/nodeTableHelper.tsx
@@ -19,7 +19,7 @@ export const createNodesRows = (nodes: NodeType[], loading: boolean) => {
               children: (
                 <div className="flex gap-2 items-center">
                   <div
-                    className="w-8 h-6 rounded-xs bg-cover bg-center bg-no-repeat"
+                    className="w-8 h-6 rounded-xs bg-cover bg-center bg-no-repeat shrink-0"
                     style={{
                       backgroundImage: `url(http://purecatamphetamine.github.io/country-flag-icons/3x2/${node.location.countryCode}.svg)`,
                     }}


### PR DESCRIPTION
### 🛠 Changes being made

Change improves the layout of the node table by adding the `shrink-0` class to the flag icon container to prevent it from shrinking.

* [`apps/web/src/utils/helpers/TableHelpers/nodeTableHelper.tsx`](diffhunk://#diff-10430d991befd23ea752f15803561f95b3920d1d5bece85429513dccf08527c5L22-R22): Added `shrink-0` class to the flag icon container to maintain its size.
### 🏎 Quality check

- [ ] Did you check the responsive design of the changes?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
