### PR TITLE
:recycle: Accounts | Link all account cards to account/[address]

### DIFF
--- a/apps/web/src/components/clientPages/accounts.tsx
+++ b/apps/web/src/components/clientPages/accounts.tsx
@@ -3,13 +3,13 @@ import { FlexGrid } from '@repo/ui/atoms';
 import { SectionHeader, TableContainer } from '@repo/ui/organisms';
 import { useSearchParams } from 'next/navigation';
 import { usePaginationAndSorting } from '../../utils/hooks/usePaginationAndSorting.ts';
-import {callGetAccounts, callGetTopAccounts} from '../../utils/api/apiCalls.tsx';
+import { callGetTopAccounts } from '../../utils/api/apiCalls.tsx';
 import { accountsTableHead } from '../../utils/helpers/tableHeaders.tsx';
 import { useBasePath } from '../../utils/hooks/useBasePath.ts';
 import { createAccountsRows } from '../../utils/helpers/TableHelpers/accountTableHelper.tsx';
 import { tokenSummaryStore } from '../../store/tokenSummaryStore.ts';
-import {useChainNetworkStore} from "../../store/chainNetworkStore.ts";
-import {TopAccountsType} from "../../utils/types.ts";
+import { useChainNetworkStore } from '../../store/chainNetworkStore.ts';
+import { TopAccountsType } from '../../utils/types.ts';
 
 export const Accounts = () => {
   const searchParams = useSearchParams();
@@ -36,7 +36,7 @@ export const Accounts = () => {
     defaultLimit: searchParams.get('limit') || '100',
     searchParams: {
       tokenID,
-    }
+    },
   });
 
   const typedAccounts = accounts as unknown as TopAccountsType;

--- a/apps/web/src/components/formattedValue.tsx
+++ b/apps/web/src/components/formattedValue.tsx
@@ -128,7 +128,7 @@ export const FormattedValue = ({
 
     if (format === 'account' && isAccountObject(value)) {
       return (
-        <Link basePath={basePath} href={`/account/${value.name ?? value.address}`}>
+        <Link basePath={basePath} href={`/account/${value.address}`}>
           {accountIconComponent ? (
             <div className={'relative inline-flex items-center gap-1'}>
               {accountIconComponent}

--- a/packages/ui/src/components/molecules/blockDetails/blockDetailsBannerText.tsx
+++ b/packages/ui/src/components/molecules/blockDetails/blockDetailsBannerText.tsx
@@ -30,7 +30,7 @@ export const BlockDetailsBannerText = ({
       </Typography>
 
       {/* SENDER */}
-      <Link basePath={basePath} href={`/account/${generatorName ?? generatorAddress}`}>
+      <Link basePath={basePath} href={`/account/${generatorAddress}`}>
         <UserAccountCard
           address={generatorAddress}
           addressColor="onBackground"

--- a/packages/ui/src/components/molecules/transaction/bannerText.tsx
+++ b/packages/ui/src/components/molecules/transaction/bannerText.tsx
@@ -41,7 +41,7 @@ export const BannerText = ({
   return (
     <div className="max-w-full flex flex-wrap items-center gap-1.5 mt-5">
       {/* SENDER */}
-      <Link basePath={basePath} href={`/account/${senderName ?? senderAddress}`}>
+      <Link basePath={basePath} href={`/account/${senderAddress}`}>
         <UserAccountCard
           address={senderAddress}
           addressColor="onBackground"
@@ -62,7 +62,7 @@ export const BannerText = ({
 
       {/* RECEIVER */}
       {receiverAddress && (
-        <Link basePath={basePath} href={`/account/${receiverName ?? receiverAddress}`}>
+        <Link basePath={basePath} href={`/account/${receiverAddress}`}>
           <UserAccountCard
             address={receiverAddress}
             addressColor="onBackground"


### PR DESCRIPTION
### 🛠 Changes being made

Changed account cards usages to only link to /address and not to name except for next-generators. People can still go to /name through a direct link. This is to fix names with spaces not working correctly

### 🏎 Quality check

- [x] Did you check the responsive design of the changes?
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?
