### PR TITLE
♻️ Events | apicall timeout set to 13000

### DIFF
--- a/apps/web/src/store/clientStore.ts
+++ b/apps/web/src/store/clientStore.ts
@@ -16,7 +16,7 @@ interface GatewayClientStore {
 export const useGatewayClientStore = create<GatewayClientStore>((set) => ({
   client: axios.create({
     baseURL: 'https://gateway-mainnet.klayr.dev/api/v1/',
-    timeout: 5000,
+    timeout: 13000,
     headers: {
       'Content-Type': 'application/json',
       Accept: 'application/json',


### PR DESCRIPTION
### 🛠 Changes being made

The change increases the timeout value for the Axios client configuration.

### 🏎 Quality check

- [x] Did you check the responsive design of the changes?
- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?
